### PR TITLE
Fix: Link to homepage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "library",
 	"description": "An easy-to-use PHP Class for accessing Instagram's API.",
 	"keywords": ["instagram", "api"],
-	"homepage": "https://github.com/Andreyco/Instagram",
+	"homepage": "https://github.com/Andreyco/Instagram-for-PHP",
 	"license": "BSD-4-Clause",
 	"authors": [
 		{


### PR DESCRIPTION
This PR
- [x] fixes the link to the package's homepage
### Current state

![screen shot 2015-06-03 at 20 27 25](https://cloud.githubusercontent.com/assets/605483/7968113/000bd662-0a2f-11e5-98c6-aee9363ad5d3.png)
