### PR TITLE
getTag requires auth set to true to return data

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -277,7 +277,7 @@ class Client {
      * @return mixed
      */
     public function getTag($name) {
-        return $this->_makeCall('tags/' . $name);
+        return $this->_makeCall('tags/' . $name,true);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -277,7 +277,7 @@ class Client {
      * @return mixed
      */
     public function getTag($name) {
-        return $this->_makeCall('tags/' . $name,true);
+        return $this->_makeCall('tags/' . $name, true);
     }
 
     /**


### PR DESCRIPTION
The updated endpoint for tag requires access token instead of client id. https://www.instagram.com/developer/endpoints/tags/. Updated the method to makeCall with auth param set to true.