### PR TITLE
GetMedia needs auth

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -248,7 +248,7 @@ class Client {
      * @return mixed
      */
     public function getMedia($id) {
-        return $this->_makeCall('media/' . $id);
+        return $this->_makeCall('media/' . $id, true);
     }
 
     /**


### PR DESCRIPTION
I think all calls need auth these days: See 
https://www.instagram.com/developer/endpoints/
`The Instagram API requires an access_token from authenticated users for each endpoint. We no longer support making requests using just the client_id.`
This change fixed this for the getmedia call, but I think in the new situation auth is always true. If you agree I can create a pull req to remove the auth option (as it will always be true).